### PR TITLE
Showing types for found definitions

### DIFF
--- a/Loogle/Find.lean
+++ b/Loogle/Find.lean
@@ -631,11 +631,11 @@ the distributed cache, it may be useful to open a scratch file, `import Mathlib`
 there, this way you will find lemmas that you have not yet imported, and the
 cache will stay up-to-date.
 
-By default `#find` only prints you names of found definitions and lemmas. You can also make print
-types by setting `find.showType` to true:
+By default `#find` prints names and types of found definitions and lemmas. You can also make it print
+names only by setting `find.showType` to `false`:
 
 ```lean
-set_option find.showTypes true
+set_option find.showTypes false
 ```
 -/
 elab(name := findSyntax) "#find " args:find_filters : command =>

--- a/Loogle/Find.lean
+++ b/Loogle/Find.lean
@@ -25,7 +25,7 @@ open Lean Meta Elab
 -/
 
 /-- Puts `MessageData` into a bulleted list -/
-def MessageData.bulletList (xs : Array (MessageData)): MessageData :=
+def MessageData.bulletList (xs : Array MessageData) : MessageData :=
   MessageData.joinSep (xs.toList.map (m!"• " ++ ·)) Format.line
 
 /-- Puts `MessageData` into a comma-separated list with `"and"` at the back (no Oxford comma).

--- a/Loogle/Find.lean
+++ b/Loogle/Find.lean
@@ -545,7 +545,7 @@ open Command
 Option to control whether `find` should print types of found lemmas
 -/
 register_option find.showTypes : Bool := {
-  defValue := false
+  defValue := true
   descr := "showing types in #f"
 }
 
@@ -641,5 +641,6 @@ set_option find.showTypes true
 elab(name := findSyntax) "#find " args:find_filters : command =>
   liftTermElabM $ elabFind args
 
+@[inherit_doc findSyntax]
 elab(name := findSyntaxTac) "#find " args:find_filters : tactic =>
   elabFind args

--- a/Tests.lean
+++ b/Tests.lean
@@ -435,3 +435,17 @@ Of these, one has a name containing "peculiar" and "the".
 -/
 #guard_msgs in
 #find "peculiar", "the"
+
+-- To make find print types of found definitions and lemmas use `find.showTypes` option
+
+set_option find.showTypes true
+set_option pp.raw false
+
+/--
+info: Found 3 definitions mentioning my_true.
+Of these, 2 have a name containing "eq".
+• my_true_eq_True : my_true = true
+• my_true_eq_true : my_true = true
+-/
+#guard_msgs in
+#find my_true, "eq"

--- a/Tests.lean
+++ b/Tests.lean
@@ -30,27 +30,27 @@ theorem my_true_eq_True : my_true = true := rfl -- intentionally capitalized
 
 /--
 info: Found 3 definitions mentioning my_true.
-• my_true
-• my_true_eq_True
-• my_true_eq_true
+• my_true : Bool
+• my_true_eq_True : my_true = true
+• my_true_eq_true : my_true = true
 -/
 #guard_msgs in
 #find my_true
 
 /--
 info: Found 3 definitions whose name contains "my_true".
-• my_true
-• my_true_eq_True
-• my_true_eq_true
+• my_true : Bool
+• my_true_eq_True : my_true = true
+• my_true_eq_true : my_true = true
 -/
 #guard_msgs in
 #find "my_true"
 
 /--
 info: Found 3 definitions whose name contains "y_tru".
-• my_true
-• my_true_eq_True
-• my_true_eq_true
+• my_true : Bool
+• my_true_eq_True : my_true = true
+• my_true_eq_true : my_true = true
 -/
 #guard_msgs in
 #find "y_tru"
@@ -58,8 +58,8 @@ info: Found 3 definitions whose name contains "y_tru".
 /--
 info: Found 3 definitions mentioning my_true.
 Of these, 2 have a name containing "eq".
-• my_true_eq_True
-• my_true_eq_true
+• my_true_eq_True : my_true = true
+• my_true_eq_true : my_true = true
 -/
 #guard_msgs in
 #find my_true, "eq"
@@ -67,8 +67,8 @@ Of these, 2 have a name containing "eq".
 /--
 info: Found 2 definitions mentioning Bool, my_true and Eq.
 Of these, 2 match your pattern(s).
-• my_true_eq_True
-• my_true_eq_true
+• my_true_eq_True : my_true = true
+• my_true_eq_true : my_true = true
 -/
 #guard_msgs in
 #find my_true = _
@@ -113,7 +113,8 @@ theorem non_linear_pattern_test2 {n m : Nat} :
 /--
 info: Found 2 definitions mentioning List.replicate, List and HAppend.hAppend.
 Of these, one matches your pattern(s).
-• non_linear_pattern_test1
+• non_linear_pattern_test1 : ∀ {n : Nat} {m : Nat},
+  List.replicate (2 * n) () = List.replicate n () ++ List.replicate n ()
 -/
 #guard_msgs in
 #find List.replicate ?n _ ++ List.replicate ?n _
@@ -121,8 +122,9 @@ Of these, one matches your pattern(s).
 /--
 info: Found 2 definitions mentioning List.replicate, List and HAppend.hAppend.
 Of these, 2 match your pattern(s).
-• non_linear_pattern_test2
-• non_linear_pattern_test1
+• non_linear_pattern_test2 : ∀ {n m : Nat}, List.replicate n () ++ List.replicate m () = List.replicate (n + m) ()
+• non_linear_pattern_test1 : ∀ {n : Nat} {m : Nat},
+  List.replicate (2 * n) () = List.replicate n () ++ List.replicate n ()
 -/
 #guard_msgs in
 #find List.replicate ?n _ ++ List.replicate ?m _
@@ -130,7 +132,8 @@ Of these, 2 match your pattern(s).
 /--
 info: Found 2 definitions mentioning List.replicate, List, Eq and HAppend.hAppend.
 Of these, one matches your pattern(s).
-• non_linear_pattern_test1
+• non_linear_pattern_test1 : ∀ {n : Nat} {m : Nat},
+  List.replicate (2 * n) () = List.replicate n () ++ List.replicate n ()
 -/
 #guard_msgs in
 #find |- _ = List.replicate ?n _ ++ List.replicate ?m _
@@ -138,7 +141,7 @@ Of these, one matches your pattern(s).
 /--
 info: Found 2 definitions mentioning List.replicate, List, Eq and HAppend.hAppend.
 Of these, one matches your pattern(s).
-• non_linear_pattern_test2
+• non_linear_pattern_test2 : ∀ {n m : Nat}, List.replicate n () ++ List.replicate m () = List.replicate (n + m) ()
 -/
 #guard_msgs in
 #find |- List.replicate ?n _ ++ List.replicate ?m _ = _
@@ -149,8 +152,8 @@ theorem hyp_ordering_test2 {n : Nat} (_ : n + n = 6 * n) (h : 0 < n) : 0 ≤ n :
 /--
 info: Found 2 definitions mentioning LE.le, LT.lt and OfNat.ofNat.
 Of these, 2 match your pattern(s).
-• hyp_ordering_test1
-• hyp_ordering_test2
+• hyp_ordering_test1 : ∀ {n : Nat}, 0 < n → n + n = 6 * n → 0 ≤ n
+• hyp_ordering_test2 : ∀ {n : Nat}, n + n = 6 * n → 0 < n → 0 ≤ n
 -/
 #guard_msgs in
 #find ⊢ 0 < ?n → _ ≤ ?n
@@ -171,7 +174,7 @@ theorem star_comm_self' {R} [Mul R] [Star R] (x : R) : star x * x = x * star x :
 /--
 info: Found 2 definitions mentioning LinearPatternTest.Star.star.
 Of these, one matches your pattern(s).
-• star_comm_self'
+• star_comm_self' : ∀ {R : Type u_1} [inst : Mul R] [inst_1 : Star R] (x : R), star x * x = x * star x
 -/
 #guard_msgs in
 #find star _
@@ -179,7 +182,7 @@ Of these, one matches your pattern(s).
 /--
 info: Found one definition mentioning HMul.hMul, LinearPatternTest.Star.star and Eq.
 Of these, one matches your pattern(s).
-• star_comm_self'
+• star_comm_self' : ∀ {R : Type u_1} [inst : Mul R] [inst_1 : Star R] (x : R), star x * x = x * star x
 -/
 #guard_msgs in
 #find star ?a * ?a = ?a * star ?_
@@ -187,7 +190,7 @@ Of these, one matches your pattern(s).
 /--
 info: Found one definition mentioning HMul.hMul, LinearPatternTest.Star.star and Eq.
 Of these, one matches your pattern(s).
-• star_comm_self'
+• star_comm_self' : ∀ {R : Type u_1} [inst : Mul R] [inst_1 : Star R] (x : R), star x * x = x * star x
 -/
 #guard_msgs in
 #find star ?a * ?a = ?b * star ?b
@@ -253,8 +256,8 @@ end DefaultingTest
 
 /--
 info: Found 2 definitions whose name contains "my_true_eq_True".
-• my_true_eq_True
-• my_true_eq_true
+• my_true_eq_True : my_true = true
+• my_true_eq_true : my_true = true
 -/
 #guard_msgs in
 #find "my_true_eq_True" -- checks for case-insensitivity
@@ -391,7 +394,7 @@ def doNotFindThisLemma : ∀ a, a = B.mk := fun _a => rfl
 /--
 info: Found one definition mentioning B, A.A1, B.ofA, B.mk and Eq.
 Of these, one matches your pattern(s).
-• findThisLemma
+• findThisLemma : B.ofA A.A1 = B.mk
 -/
 #guard_msgs in
 #find A.A1 = B.mk
@@ -400,7 +403,7 @@ Of these, one matches your pattern(s).
 /--
 info: Found one definition mentioning B, A.A1, B.ofA, B.mk and Eq.
 Of these, one matches your pattern(s).
-• findThisLemma
+• findThisLemma : B.ofA A.A1 = B.mk
 -/
 #guard_msgs in
 #find Eq B.mk A.A1
@@ -411,7 +414,7 @@ set_option pp.raw true
 /--
 info: Found one definition mentioning B, A.A1, B.ofA, B.mk and Eq.
 Of these, one matches your pattern(s).
-• findThisLemma
+• findThisLemma : Eq.{1} B (B.ofA A.A1) B.mk
 -/
 #guard_msgs in
 #find ↑A.A1 = B.mk
@@ -421,8 +424,8 @@ def this_peculiar_name_repeats_a_peculiar_substring := true
 def this_other_peculiar_name_repeats_a_peculiar_substring := true
 /--
 info: Found 2 definitions whose name contains "peculiar".
-• this_other_peculiar_name_repeats_a_peculiar_substring
-• this_peculiar_name_repeats_a_peculiar_substring
+• this_other_peculiar_name_repeats_a_peculiar_substring : Bool
+• this_peculiar_name_repeats_a_peculiar_substring : Bool
 -/
 #guard_msgs in
 #find "peculiar"
@@ -431,7 +434,7 @@ info: Found 2 definitions whose name contains "peculiar".
 /--
 info: Found 2 definitions whose name contains "peculiar".
 Of these, one has a name containing "peculiar" and "the".
-• this_other_peculiar_name_repeats_a_peculiar_substring
+• this_other_peculiar_name_repeats_a_peculiar_substring : Bool
 -/
 #guard_msgs in
 #find "peculiar", "the"

--- a/Tests.lean
+++ b/Tests.lean
@@ -439,16 +439,15 @@ Of these, one has a name containing "peculiar" and "the".
 #guard_msgs in
 #find "peculiar", "the"
 
--- To make find print types of found definitions and lemmas use `find.showTypes` option
+-- To make find not to print types of found definitions and lemmas use `find.showTypes` option
 
-set_option find.showTypes true
-set_option pp.raw false
+set_option find.showTypes false
 
 /--
 info: Found 3 definitions mentioning my_true.
 Of these, 2 have a name containing "eq".
-• my_true_eq_True : my_true = true
-• my_true_eq_true : my_true = true
+• my_true_eq_True
+• my_true_eq_true
 -/
 #guard_msgs in
 #find my_true, "eq"


### PR DESCRIPTION
Hey! Thank you for an amazing tool! That is something I have been missing from other theorem provers like Coq.

However, sometimes I want `#find` to print types of lemmas and definitions which it has found. The reason for that, is that for me, types are much more relevant than names.  When I see the list of suggestion, I first try to find the full type which I have in mind, and only then look at the correspondent name. 

Here I implement an option `find.showTypes`, setting which to true will configure `#find` to show types as well. 