### PR TITLE
Fix typo "woould" in blurb

### DIFF
--- a/blurb.html
+++ b/blurb.html
@@ -51,7 +51,7 @@ Loogle will return lemmas which match <em>all</em> of them. The
 search<br />
 🔍 <a
 href="?q=Real.sin,+%22two%22,+tsum,+_+*+_,+_+%5E+_,+%7C-+_+%3C+_+→+_"><code>Real.sin, "two", tsum, _ * _, _ ^ _, |- _ &lt; _ → _</code></a><br />
-woould find all lemmas which mention the constants <code>Real.sin</code>
+would find all lemmas which mention the constants <code>Real.sin</code>
 and <code>tsum</code>, have <code>"two"</code> as a substring of the
 lemma name, include a product and a power somewhere in the type,
 <em>and</em> have a hypothesis of the form <code>_ &lt; _</code> (if

--- a/blurb.md
+++ b/blurb.md
@@ -41,7 +41,7 @@ Loogle finds definitions and lemmas in various ways:
 If you pass more than one such search filter, separated by commas Loogle will return lemmas which match _all_ of them.
 The search\
 🔍 [`Real.sin, "two", tsum, _ * _, _ ^ _, |- _ < _ → _`](?q=Real.sin,+"two",+tsum,+_+*+_,+_+^+_,+|-+_+<+_+→+_)\
-woould find all lemmas which mention the constants `Real.sin` and `tsum`, have `"two"` as a
+would find all lemmas which mention the constants `Real.sin` and `tsum`, have `"two"` as a
 substring of the lemma name, include a product and a power somewhere in the type, *and* have a
 hypothesis of the form `_ < _` (if there were any such lemmas). Metavariables (`?a`) are assigned independently in each filter.
 


### PR DESCRIPTION
I found this typo on https://loogle.lean-lang.org/.