### PR TITLE
[feature] Server: Limit results returned in /json endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -311,6 +311,16 @@ class MyHandler(prometheus_client.MetricsHandler):
 
 
             if want_json:
+                if "error" not in result and "limit" in params:
+                    try:
+                        limit = int(params["limit"][0])
+                        if limit < 0:
+                            self.return400()
+                            return
+                        result["hits"] = result["hits"][:limit]
+                    except ValueError:
+                        self.return400()
+                        return
                 self.returnJSON(result)
                 return
 


### PR DESCRIPTION
This PR add the capability to limit the number of results returned via the /json endpoint using a query parameter:

`/json?q=Real.sin&limit=3`