### PR TITLE
refactor: use the module system

### DIFF
--- a/Loogle.lean
+++ b/Loogle.lean
@@ -249,7 +249,7 @@ unsafe def loogleCli : CliM PUnit := do
       if opts.interactive
       then interactive index print
 
-unsafe def main (args : List String) : IO Unit := do
+public unsafe def main (args : List String) : IO Unit := do
   match (← (loogleCli.run args |>.run' {}).run) with
     | .ok _ => pure ()
     | .error e => IO.println e.toString

--- a/Loogle.lean
+++ b/Loogle.lean
@@ -1,10 +1,14 @@
-import Lean.Meta
-import Lake.CLI.Error
-import Lake.Util.Cli
+module
 
-import Loogle.Find
+public import Lean.Meta
+public import Lake.CLI.Error
+public import Lake.Util.Cli
 
-import Seccomp
+public import Loogle.Find
+
+public import Seccomp
+
+import Lean.PrettyPrinter.Delaborator.Builtins
 
 set_option autoImplicit false
 
@@ -31,7 +35,7 @@ end RunParser
 open Lean Core Meta Elab Term Command
 open Loogle
 
-instance : ToExpr System.FilePath where
+meta instance : ToExpr System.FilePath where
   toTypeExpr := Lean.mkConst ``System.FilePath
   toExpr path := mkApp (Lean.mkConst ``System.FilePath.mk) (toExpr path.1)
 

--- a/Loogle/BaseIOThunk.lean
+++ b/Loogle/BaseIOThunk.lean
@@ -1,4 +1,6 @@
-import Std.Sync.Mutex
+module
+
+public import Std.Sync.Mutex
 
 /-!
 # Monadic version of `Thunk`
@@ -8,6 +10,8 @@ This file defines `BaseIO.Thunk` and `IO.Thunk`.
 It makes the choice that errors are cached just like values,
 as opposed to declaring them uncacheable as Python's `functools` caching operations do.
 -/
+
+public section
 
 /-- A version of `Thunk` that runs in `BaseIO`.
 

--- a/Loogle/BlackListed.lean
+++ b/Loogle/BlackListed.lean
@@ -4,7 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Simon Hudon, Scott Morrison, Keeley Hoek, Robert Y. Lewis,
 Floris van Doorn, E.W.Ayers, Arthur Paulino
 -/
-import Lean
+module
+
+public import Lean
+
+@[expose] public section
 
 namespace Loogle
 

--- a/Loogle/Cache.lean
+++ b/Loogle/Cache.lean
@@ -3,7 +3,11 @@ Copyright (c) 2023 Joachim Breitner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joachim Breitner
 -/
-import Batteries.Util.Cache
+module
+
+public import Batteries.Util.Cache
+
+@[expose] public section
 
 open Lean Meta
 

--- a/Loogle/Find.lean
+++ b/Loogle/Find.lean
@@ -3,20 +3,24 @@ Copyright (c) 2023 Joachim Breitner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joachim Breitner
 -/
-import Lean
-import Batteries.Data.String.Matcher
-import Batteries.Util.Pickle
+module
 
-import Loogle.Cache
-import Loogle.NameRel
-import Loogle.TreeMap
-import Loogle.BlackListed
-import Loogle.Trie
-import Loogle.BaseIOThunk
+public import Lean
+public import Batteries.Data.String.Matcher
+public import Batteries.Util.Pickle
+
+public import Loogle.Cache
+public import Loogle.NameRel
+public import Loogle.TreeMap
+public import Loogle.BlackListed
+public import Loogle.Trie
+public import Loogle.BaseIOThunk
 
 /-!
 # The `#find` command and tactic.
 -/
+
+@[expose] public section
 
 open Lean Meta Elab
 
@@ -95,7 +99,7 @@ def canMatch : HeadIndex → HeadIndex → Bool
 /-- A predicate on `ConstantInfo` -/
 def ConstMatcher := ConstantInfo → MetaM Bool
 
-private partial def matchHyps : List Expr → List Expr → List Expr → MetaM Bool
+partial def matchHyps : List Expr → List Expr → List Expr → MetaM Bool
   | p::ps, oldHyps, h::newHyps => do
     let pt ← inferType p
     let t ← inferType h
@@ -178,7 +182,7 @@ of lemma names.
 
 /-- For all names `n` mentioned in the type of the constant `c`, add a mapping from
 `n` to `c.name` to the relation. -/
-private def addDecl (name : Lean.Name) (c : ConstantInfo) (m : NameRel) : MetaM NameRel := do
+def addDecl (name : Lean.Name) (c : ConstantInfo) (m : NameRel) : MetaM NameRel := do
   if ← Loogle.isBlackListed name then
     return m
   let consts := c.type.getUsedConstantsAsSet
@@ -288,7 +292,7 @@ The following functions are rather hackish, maybe there can be a more principled
 -/
 
 /-- Equality on `SourceInfo` -/
-private def SourceInfo.beq  : SourceInfo → SourceInfo → Bool
+def SourceInfo.beq  : SourceInfo → SourceInfo → Bool
   | .original _ p1 _ p2, .original _ p3 _ p4
   | .original _ p1 _ p2, .synthetic p3 p4 _
   | .synthetic p1 p2 _, .synthetic p3 p4 _
@@ -577,86 +581,3 @@ def elabFind (args : TSyntax `Loogle.Find.find_filters) : TermElabM Unit := do
         let showTypes := (<- getOptions).get find.showTypes.name find.showTypes.defValue
         let names := result.hits.map $ fun x=> (x.1.name, x.1.type)
         Lean.logInfo $ result.header ++ (← MessageData.bulletListOfConstsAndTypes names showTypes)
-
-
-/--
-The `#find` command finds definitions and lemmas in various ways. One can search by: the constants
-involved in the type; a substring of the name; a subexpression of the type; or a subexpression
-located in the return type or a hypothesis specifically. All of these search methods can be
-combined in a single query, comma-separated.
-
-1. By constant:
-   ```lean
-   #find Real.sin
-   ```
-   finds all lemmas whose statement somehow mentions the sine function.
-
-2. By lemma name substring:
-   ```lean
-   #find "differ"
-   ```
-   finds all lemmas that have `"differ"` somewhere in their lemma _name_.
-   This check is case-insensitive.
-
-3. By subexpression:
-   ```lean
-   #find _ * (_ ^ _)
-   ```
-   finds all lemmas whose statements somewhere include a product where the second argument is
-   raised to some power.
-
-   The pattern can also be non-linear, as in
-   ```lean
-   #find Real.sqrt ?a * Real.sqrt ?a
-   ```
-
-   If the pattern has parameters, they are matched in any order. Both of these will find `List.map`:
-   ```
-   #find (?a -> ?b) -> List ?a -> List ?b
-   #find List ?a -> (?a -> ?b) -> List ?b
-   ```
-
-4. By main conclusion:
-   ```lean
-   #find ⊢ tsum _ = _ * tsum _
-   ```
-   finds all lemmas where the conclusion (the subexpression to the right of all `→` and `∀`) has the
-   given shape.
-
-   As before, if the pattern has parameters, they are matched against the hypotheses of
-   the lemma in any order; for example,
-   ```lean
-   #find ⊢ _ < _ → tsum _ < tsum _
-   ```
-   will find `tsum_lt_tsum` even though the hypothesis `f i < g i` is not the last.
-
-
-If you pass more than one such search filter, `#find` will return lemmas which match _all_ of them.
-The search
-```lean
-#find Real.sin, "two", tsum,  _ * _, _ ^ _, ⊢ _ < _ → _
-```
-will find all lemmas which mention the constants `Real.sin` and `tsum`, have `"two"` as a
-substring of the lemma name, include a product and a power somewhere in the type, *and* have a
-hypothesis of the form `_ < _`.
-
-`#find` maintains an index of which lemmas mention which other constants and name fragments.
-If you have downloaded the olean cache for mathlib, the index will be precomputed. If not,
-the _first_ use of `#find` in a module will be slow (in the order of minutes). If you cannot use
-the distributed cache, it may be useful to open a scratch file, `import Mathlib`, and use `#find`
-there, this way you will find lemmas that you have not yet imported, and the
-cache will stay up-to-date.
-
-By default `#find` prints names and types of found definitions and lemmas. You can also make it print
-names only by setting `find.showType` to `false`:
-
-```lean
-set_option find.showTypes false
-```
--/
-elab(name := findSyntax) "#find " args:find_filters : command =>
-  liftTermElabM $ elabFind args
-
-@[inherit_doc findSyntax]
-elab(name := findSyntaxTac) "#find " args:find_filters : tactic =>
-  elabFind args

--- a/Loogle/FindCommand.lean
+++ b/Loogle/FindCommand.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2023 Joachim Breitner. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joachim Breitner
+-/
+module
+
+public meta import Loogle.Find
+
+public meta section
+
+namespace Loogle.Find
+
+open Lean.Elab.Command
+
+/--
+The `#find` command finds definitions and lemmas in various ways. One can search by: the constants
+involved in the type; a substring of the name; a subexpression of the type; or a subexpression
+located in the return type or a hypothesis specifically. All of these search methods can be
+combined in a single query, comma-separated.
+
+1. By constant:
+   ```lean
+   #find Real.sin
+   ```
+   finds all lemmas whose statement somehow mentions the sine function.
+
+2. By lemma name substring:
+   ```lean
+   #find "differ"
+   ```
+   finds all lemmas that have `"differ"` somewhere in their lemma _name_.
+   This check is case-insensitive.
+
+3. By subexpression:
+   ```lean
+   #find _ * (_ ^ _)
+   ```
+   finds all lemmas whose statements somewhere include a product where the second argument is
+   raised to some power.
+
+   The pattern can also be non-linear, as in
+   ```lean
+   #find Real.sqrt ?a * Real.sqrt ?a
+   ```
+
+   If the pattern has parameters, they are matched in any order. Both of these will find `List.map`:
+   ```
+   #find (?a -> ?b) -> List ?a -> List ?b
+   #find List ?a -> (?a -> ?b) -> List ?b
+   ```
+
+4. By main conclusion:
+   ```lean
+   #find ⊢ tsum _ = _ * tsum _
+   ```
+   finds all lemmas where the conclusion (the subexpression to the right of all `→` and `∀`) has the
+   given shape.
+
+   As before, if the pattern has parameters, they are matched against the hypotheses of
+   the lemma in any order; for example,
+   ```lean
+   #find ⊢ _ < _ → tsum _ < tsum _
+   ```
+   will find `tsum_lt_tsum` even though the hypothesis `f i < g i` is not the last.
+
+
+If you pass more than one such search filter, `#find` will return lemmas which match _all_ of them.
+The search
+```lean
+#find Real.sin, "two", tsum,  _ * _, _ ^ _, ⊢ _ < _ → _
+```
+will find all lemmas which mention the constants `Real.sin` and `tsum`, have `"two"` as a
+substring of the lemma name, include a product and a power somewhere in the type, *and* have a
+hypothesis of the form `_ < _`.
+
+`#find` maintains an index of which lemmas mention which other constants and name fragments.
+If you have downloaded the olean cache for mathlib, the index will be precomputed. If not,
+the _first_ use of `#find` in a module will be slow (in the order of minutes). If you cannot use
+the distributed cache, it may be useful to open a scratch file, `import Mathlib`, and use `#find`
+there, this way you will find lemmas that you have not yet imported, and the
+cache will stay up-to-date.
+
+By default `#find` prints names and types of found definitions and lemmas. You can also make it print
+names only by setting `find.showType` to `false`:
+
+```lean
+set_option find.showTypes false
+```
+-/
+elab(name := findSyntax) "#find " args:find_filters : command =>
+  liftTermElabM $ elabFind args
+
+@[inherit_doc findSyntax]
+elab(name := findSyntaxTac) "#find " args:find_filters : tactic =>
+  elabFind args

--- a/Loogle/NameRel.lean
+++ b/Loogle/NameRel.lean
@@ -3,13 +3,16 @@ Copyright (c) 2023 Joachim Breitner. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Joachim Breitner
 -/
+module
 
-import Lean.Data.NameMap
-import Lean.Declaration
+public import Lean.Data.NameMap
+public import Lean.Declaration
 
 /-!
 ## A data structure for a relation on names
 -/
+
+@[expose] public section
 
 open Lean Meta
 

--- a/Loogle/TreeMap.lean
+++ b/Loogle/TreeMap.lean
@@ -1,4 +1,9 @@
-import Std
+module
+
+public import Std
+
+@[expose] public section
+
 namespace Std.TreeSet
 
 variable {α : Type _} {cmp}

--- a/Loogle/Trie.lean
+++ b/Loogle/Trie.lean
@@ -8,8 +8,12 @@ A string trie data structure, used for tokenizing the Lean language.
 Adapted from Lean.Data.Trie to use path compression.
 
 -/
-import Lean.Data.Format
-import Batteries.Data.Array
+module
+
+public import Lean.Data.Format
+public import Batteries.Data.Array
+
+@[expose] public section
 
 namespace Loogle
 
@@ -188,7 +192,7 @@ def findPrefix (t : Trie α) (pre : String) : Array α := go t 0
 
 
 open Lean in
-private partial def toStringAux {α : Type} : Trie α → List Format
+partial def toStringAux {α : Type} : Trie α → List Format
   | leaf _ => []
   | path _ ps _ t =>
     [ format (repr ps.data), Format.group $ Format.nest 4 $ flip Format.joinSep Format.line $ toStringAux t ]

--- a/Seccomp.lean
+++ b/Seccomp.lean
@@ -1,4 +1,8 @@
-import Lean
+module
+
+public import Lean
+
+@[expose] public section
 
 syntax (name := ifEnv)
   "#ifEnv " str " then " ppLine command " else " command :  command

--- a/Tests.lean
+++ b/Tests.lean
@@ -1,4 +1,4 @@
-import Loogle.Find
+import Loogle.FindCommand
 
 -- We want the following tests to be self-contained.
 -- Therefore we erase all knowledge about imported definitios from find:


### PR DESCRIPTION
For now LoogleMathlibCache does not use `module`, since this might be relying on the non-module behavior

It was convenient here to split `Find` into `Find` (the API) and `FindCommand` (the meta-level command).