### PR TITLE
remove upstreamed defs

### DIFF
--- a/Loogle/Cache.lean
+++ b/Loogle/Cache.lean
@@ -22,9 +22,7 @@ the second will store declarations from imports (and will hopefully be "read-onl
 def DeclCache2 (α : Type) : Type := DeclCache (α × α)
 
 instance (α : Type) [h : Nonempty α] : Nonempty (DeclCache2 α) :=
-  -- inferInstanceAs (Nonempty (DeclCache (α × α)))
-  -- work around lack of Prod.nonempty in std/core:
-  h.elim fun x => @instNonemptyDeclCache _ ⟨x,x⟩
+  inferInstanceAs (Nonempty (DeclCache (α × α)))
 
 /--
 Creates a `DeclCache`.

--- a/Loogle/Find.lean
+++ b/Loogle/Find.lean
@@ -471,7 +471,7 @@ def find (index : Index) (args : TSyntax ``find_filters) (maxShown := 200) :
         -- Query the declaration cache
         let (m₁, m₂) ← index.nameRelCache.get
         let hits := .intersects_loogle <| needles.toArray.map <| fun needle =>
-          ((m₁.find needle).union_loogle (m₂.find needle)).insert needle
+          ((m₁.find needle).union (m₂.find needle)).insert needle
 
         let needlesList := .andList (needles.toList.map .ofConstName)
         if hits.size == 1 then

--- a/Loogle/TreeMap.lean
+++ b/Loogle/TreeMap.lean
@@ -10,13 +10,6 @@ variable {α : Type _} {cmp}
 
 -- from https://github.com/leanprover-community/mathlib4/blob/c0a057e453edb8d89d4b2eaeeb8e0eb0f714f715/Mathlib/Tactic/Linarith/Oracle/FourierMotzkin.lean#L40-L45
 
-/--
-`O(n₂ * log (n₁ + n₂))`. Merges the maps `t₁` and `t₂`.
-If equal keys exist in both, the key from `t₂` is preferred.
--/
-def union_loogle (t₁ t₂ : TreeSet α cmp) : TreeSet α cmp :=
-  t₂.foldl .insert t₁
-
 /-- The intersection of a (non-empty) array of `RBTree`s. If
 the input is empty, the empty tree is returned. -/
 def intersects_loogle (ts : Array (TreeSet α cmp)) : TreeSet α cmp :=
@@ -26,6 +19,5 @@ def intersects_loogle (ts : Array (TreeSet α cmp)) : TreeSet α cmp :=
   let ts := ts.qsort (·.size > ·.size)
   ts.back!.foldl (init := {}) fun s m =>
     if ts.pop.all (·.contains m) then s.insert m else s
-
 
 end Std.TreeSet


### PR DESCRIPTION
`Std.TreeSet.union` and `Nonempty (Prod _ _)` now exist.