### PR TITLE
fix: VSCode's Loogle command has no default shortcut

### DIFF
--- a/blurb.html
+++ b/blurb.html
@@ -1,7 +1,7 @@
 <h2 id="about">About</h2>
 <p>Loogle searches Lean and Mathlib definitions and theorems.</p>
 <p>You can use Loogle from within the Lean4 VSCode language extension
-using (by default) Ctrl-K Ctrl-S. You can also try the
+using the Loogle command from the command palette. You can also try the
 <code>#loogle</code> command from <a
 href="https://github.com/leanprover-community/LeanSearchClient">LeanSearchClient</a>,
 the <a href="https://github.com/nomeata/loogle">CLI version</a>, the <a

--- a/blurb.md
+++ b/blurb.md
@@ -1,7 +1,7 @@
 ## About
 Loogle searches Lean and Mathlib definitions and theorems.
 
-You can use Loogle from within the Lean4 VSCode language extension using (by default) Ctrl-K Ctrl-S. You can also try the `#loogle` command from [LeanSearchClient](https://github.com/leanprover-community/LeanSearchClient), the [CLI version](https://github.com/nomeata/loogle), the [Loogle VS Code extension](https://marketplace.visualstudio.com/items?itemName=ShreyasSrinivas.loogle-lean), the [`lean.nvim` integration](https://github.com/Julian/lean.nvim#features) or the [Zulip bot](https://github.com/nomeata/loogle#zulip-bot).
+You can use Loogle from within the Lean4 VSCode language extension using the Loogle command from the command palette. You can also try the `#loogle` command from [LeanSearchClient](https://github.com/leanprover-community/LeanSearchClient), the [CLI version](https://github.com/nomeata/loogle), the [Loogle VS Code extension](https://marketplace.visualstudio.com/items?itemName=ShreyasSrinivas.loogle-lean), the [`lean.nvim` integration](https://github.com/Julian/lean.nvim#features) or the [Zulip bot](https://github.com/nomeata/loogle#zulip-bot).
 
 ## Usage
 


### PR DESCRIPTION
The default shortcut was deleted in leanprover/vscode-lean4#620 a year ago