### PR TITLE
server.py: pool of loogle workers, load-shed instead of queueing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,14 @@ jobs:
       - uses: leanprover/lean-action@v1
       - name: End-to-end tests (lake-env + lake-exe)
         run: ./tests/run.sh
+
+  frontend-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: HTTP frontend tests (mocked backend)
+        run: python3 frontend-tests/test_server.py

--- a/frontend-tests/mock-loogle.py
+++ b/frontend-tests/mock-loogle.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Mock loogle backend for testing server.py.
+
+Speaks the same line-based JSON protocol as `loogle --json --interactive`:
+prints `Loogle is ready.` on stdout, then for each newline-terminated query
+read from stdin, writes one JSON line to stdout.
+
+Pass to server.py with `--loogle-bin ./mock-loogle.py`. Any --json /
+--interactive / other args are accepted and ignored.
+
+Special query strings (matched verbatim) trigger specific behaviours:
+
+  block <path>     Open <path> for reading and block until a writer attaches
+                   *and* sends at least one byte. The test driver creates
+                   <path> as a FIFO and pairs the open() to know exactly
+                   when the worker is committed — no sleeps, no races.
+                   Returns once unblocked.
+  crash            Exit with code 1 (simulates a crashed backend).
+  sandbox          Kill self with SIGSYS so `Popen.poll()` returns -31
+                   (the sandbox-escape path).
+  error            Return {"error": "mock error message"}.
+  <anything else>  Return a sample result with one hit.
+
+Env vars:
+  MOCK_NO_GREETING=1       Send a wrong greeting line, to exercise the
+                           greeting-failure path in Loogle.start().
+  MOCK_FAIL_GREETING_IF=<path>
+                           Send a wrong greeting iff <path> exists at
+                           startup. Lets a test arm the next subprocess
+                           invocation to fail without affecting the
+                           first one — useful for exercising the
+                           "restart itself failed" branch.
+"""
+import sys
+import os
+import json
+import signal
+
+
+def handle(query):
+    if query == "crash":
+        sys.exit(1)
+    if query == "sandbox":
+        os.kill(os.getpid(), signal.SIGSYS)  # signal 31 on Linux -> poll() == -31
+        sys.exit(1)  # in case the signal is queued
+    if query == "error":
+        return {"error": "mock error message"}
+    if query.startswith("block "):
+        path = query[len("block "):]
+        # open() on a FIFO blocks until a writer attaches; the subsequent
+        # read() blocks until the writer sends a byte. Both halves give
+        # the test a deterministic synchronization point with no sleeps.
+        with open(path, "r") as f:
+            f.read(1)
+        return {"header": f"unblocked {path}", "count": 0, "hits": [], "heartbeats": 0}
+    return {
+        "header": f"Mock results for: {query}",
+        "count": 1,
+        "hits": [{
+            "name": "Mock.example",
+            "module": "Mock.Example",
+            "type": "Nat → Nat",
+        }],
+        "heartbeats": 1,
+    }
+
+
+def main():
+    fail_if = os.environ.get("MOCK_FAIL_GREETING_IF")
+    bad = bool(os.environ.get("MOCK_NO_GREETING")) \
+        or (fail_if is not None and os.path.exists(fail_if))
+    if bad:
+        sys.stdout.write("not a greeting\n")
+    else:
+        sys.stdout.write("Loogle is ready.\n")
+    sys.stdout.flush()
+
+    for line in sys.stdin:
+        query = line.rstrip("\n")
+        result = handle(query)
+        sys.stdout.write(json.dumps(result) + "\n")
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend-tests/mock-loogle.py
+++ b/frontend-tests/mock-loogle.py
@@ -30,11 +30,16 @@ Env vars:
                            invocation to fail without affecting the
                            first one — useful for exercising the
                            "restart itself failed" branch.
+  MOCK_HANG_BEFORE_GREETING=1
+                           Block forever before printing the greeting,
+                           so the test can exercise the startup-timeout
+                           path in Loogle._read_greeting.
 """
 import sys
 import os
 import json
 import signal
+import time
 
 
 def handle(query):
@@ -66,6 +71,10 @@ def handle(query):
 
 
 def main():
+    if os.environ.get("MOCK_HANG_BEFORE_GREETING"):
+        # Sleep well past any reasonable startup-timeout. The server
+        # will kill us when its timeout fires.
+        time.sleep(86400)
     fail_if = os.environ.get("MOCK_FAIL_GREETING_IF")
     bad = bool(os.environ.get("MOCK_NO_GREETING")) \
         or (fail_if is not None and os.path.exists(fail_if))

--- a/frontend-tests/test_server.py
+++ b/frontend-tests/test_server.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""End-to-end tests for server.py, driven against mock-loogle.py.
+
+Race-free: every concurrency assertion synchronizes through a FIFO that
+the mock blocks on. The test pairs the FIFO's open() with the mock's
+open() to know exactly when the worker has been taken from the pool —
+no sleeps gating concurrent state.
+
+Run directly:   ./frontend-tests/test_server.py
+Or via Python:  python3 -m unittest frontend-tests.test_server -v
+"""
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TESTS_DIR = Path(__file__).resolve().parent
+MOCK_PATH = TESTS_DIR / "mock-loogle.py"
+
+# Polling intervals used while waiting for an observable state change
+# (worker readiness, log line appearing, port opening). These are NOT
+# synchronization sleeps — they just bound how often we re-check a
+# condition that will deterministically become true.
+POLL_INTERVAL = 0.02
+DEFAULT_TIMEOUT = 15.0
+
+WORKER_READY_RE = re.compile(r"Worker \d+ ready\.")
+
+
+def _free_port():
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+class Server:
+    """Lifecycle wrapper around a `python3 server.py` subprocess."""
+
+    def __init__(self, workers, env_overrides=None):
+        self.workers = workers
+        self.env_overrides = env_overrides or {}
+        self.port = _free_port()
+        self.proc = None
+        self.log_path = None
+        self._log_fh = None
+
+    @property
+    def base_url(self):
+        return f"http://127.0.0.1:{self.port}"
+
+    def start(self):
+        fd, log_path = tempfile.mkstemp(prefix="loogle-test-", suffix=".log")
+        self._log_fh = os.fdopen(fd, "wb")
+        self.log_path = Path(log_path)
+        env = os.environ.copy()
+        env.update(self.env_overrides)
+        self.proc = subprocess.Popen(
+            [sys.executable, "server.py",
+             "--host", "127.0.0.1",
+             "--port", str(self.port),
+             "--workers", str(self.workers),
+             "--restart-delay", "0.05",
+             "--loogle-bin", str(MOCK_PATH)],
+            cwd=str(ROOT),
+            env=env,
+            stdout=self._log_fh,
+            stderr=subprocess.STDOUT,
+        )
+
+    def stop(self):
+        if self.proc and self.proc.poll() is None:
+            self.proc.kill()
+            self.proc.wait()
+        if self._log_fh:
+            self._log_fh.close()
+            self._log_fh = None
+        if self.log_path and self.log_path.exists():
+            self.log_path.unlink()
+
+    def _read_log(self):
+        if not self.log_path or not self.log_path.exists():
+            return ""
+        return self.log_path.read_text(errors="replace")
+
+    def _assert_alive(self):
+        if self.proc.poll() is not None:
+            raise RuntimeError(
+                f"server exited with code {self.proc.returncode}\n--- log ---\n{self._read_log()}")
+
+    def wait_listening(self, timeout=DEFAULT_TIMEOUT):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            self._assert_alive()
+            try:
+                with socket.create_connection(("127.0.0.1", self.port), timeout=0.2):
+                    return
+            except OSError:
+                time.sleep(POLL_INTERVAL)
+        raise RuntimeError(f"server never opened port {self.port}\n--- log ---\n{self._read_log()}")
+
+    def wait_workers_ready(self, n, timeout=DEFAULT_TIMEOUT):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            self._assert_alive()
+            if len(WORKER_READY_RE.findall(self._read_log())) >= n:
+                return
+            time.sleep(POLL_INTERVAL)
+        raise RuntimeError(
+            f"only saw {len(WORKER_READY_RE.findall(self._read_log()))}/{n} workers ready\n"
+            f"--- log ---\n{self._read_log()}")
+
+    def wait_log(self, needle, timeout=DEFAULT_TIMEOUT):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if needle in self._read_log():
+                return
+            time.sleep(POLL_INTERVAL)
+        raise RuntimeError(f"log never contained {needle!r}\n--- log ---\n{self._read_log()}")
+
+
+def _do_request(req):
+    """Run a urllib request, returning (status, headers_dict, body_text).
+    Treats 4xx/5xx as values rather than exceptions."""
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return r.status, dict(r.headers), r.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        return e.code, dict(e.headers), e.read().decode("utf-8")
+
+
+def http_get(server, path):
+    req = urllib.request.Request(server.base_url + path)
+    return _do_request(req)
+
+
+def http_post_json(server, path, payload):
+    req = urllib.request.Request(
+        server.base_url + path,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    return _do_request(req)
+
+
+class WorkerHold:
+    """Hold one worker on the server by issuing a `block <fifo>` query.
+
+    Usage::
+
+        with WorkerHold(server) as hold:
+            # control is yielded only after the worker is committed
+            # (mock is inside read()) — assert overload state here.
+            ...
+        # __exit__ releases the FIFO and joins the request thread.
+        assert hold.status == 200
+    """
+
+    def __init__(self, server):
+        self.server = server
+        self.fifo = Path(tempfile.mkdtemp(prefix="loogle-test-")) / "f"
+        self._fd = None
+        self._thread = None
+        self.status = None
+        self.body = None
+        self.headers = None
+        self._error = None
+
+    def __enter__(self):
+        os.mkfifo(str(self.fifo))
+        encoded = urllib.parse.quote(f"block {self.fifo}")
+        url = self.server.base_url + "/json?q=" + encoded
+
+        def fetch():
+            try:
+                self.status, self.headers, self.body = _do_request(
+                    urllib.request.Request(url))
+            except Exception as e:
+                self._error = e
+
+        self._thread = threading.Thread(target=fetch, daemon=True)
+        self._thread.start()
+        # Pair the FIFO. open(WR) blocks until the mock has opened the
+        # read side, which only happens AFTER server.py's pool.get()
+        # committed and the mock has read the query. When this returns:
+        # - the worker is out of the pool,
+        # - the mock is parked in read(), waiting for us to write.
+        self._fd = os.open(str(self.fifo), os.O_WRONLY)
+        return self
+
+    def __exit__(self, *exc):
+        if self._fd is not None:
+            try:
+                os.write(self._fd, b"x")
+            finally:
+                os.close(self._fd)
+                self._fd = None
+        if self._thread is not None:
+            self._thread.join(timeout=15)
+        try:
+            self.fifo.unlink()
+        except OSError:
+            pass
+        try:
+            self.fifo.parent.rmdir()
+        except OSError:
+            pass
+        if self._error is not None:
+            raise self._error
+
+
+# ---------------------------------------------------------------------------
+# Single-worker scenarios
+# ---------------------------------------------------------------------------
+
+class SingleWorkerTests(unittest.TestCase):
+    server: Server
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server = Server(workers=1)
+        cls.server.start()
+        cls.server.wait_listening()
+        cls.server.wait_workers_ready(1)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.stop()
+
+    def test_normal_query_returns_hit(self):
+        status, _, body = http_get(self.server, "/json?q=hello")
+        self.assertEqual(status, 200)
+        data = json.loads(body)
+        self.assertEqual(data["hits"][0]["name"], "Mock.example")
+
+    def test_backend_error_surfaces_in_200(self):
+        status, _, body = http_get(self.server, "/json?q=error")
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(body)["error"], "mock error message")
+
+    def test_json_load_shed(self):
+        with WorkerHold(self.server) as hold:
+            status, headers, body = http_get(self.server, "/json?q=hello")
+            self.assertEqual(status, 503)
+            self.assertEqual(headers.get("Retry-After"), "5")
+            self.assertIn("under load", json.loads(body).get("error", ""))
+        self.assertEqual(hold.status, 200)
+
+    def test_html_load_shed(self):
+        with WorkerHold(self.server) as hold:
+            status, headers, body = http_get(self.server, "/?q=hello")
+            self.assertEqual(status, 503)
+            self.assertEqual(headers.get("Retry-After"), "5")
+            self.assertIn("Loogle is currently under load", body)
+        self.assertEqual(hold.status, 200)
+
+    def test_zulipbot_load_shed_stays_200(self):
+        with WorkerHold(self.server) as hold:
+            status, _, body = http_post_json(
+                self.server, "/zulipbot",
+                {"data": "@**loogle** anything"})
+            self.assertEqual(status, 200)
+            self.assertIn("under load", json.loads(body)["content"])
+        self.assertEqual(hold.status, 200)
+
+    def test_z_crash_triggers_restart(self):
+        # Prefixed `z_` so it runs after the load-shed tests (unittest sorts
+        # alphabetically). The 5s restart-wait inside server.py burns real
+        # wall clock, so we'd rather pay it once.
+        status, _, body = http_get(self.server, "/json?q=crash")
+        self.assertEqual(status, 200)
+        self.assertIn("died with code", json.loads(body)["error"])
+        # Worker is respawned synchronously inside the same request, so the
+        # next call should succeed without further waiting.
+        status, _, body = http_get(self.server, "/json?q=after-crash")
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(body)["hits"][0]["name"], "Mock.example")
+
+    def test_z_sandbox_triggers_restart(self):
+        status, _, body = http_get(self.server, "/json?q=sandbox")
+        self.assertEqual(status, 200)
+        self.assertIn("sandbox", json.loads(body)["error"])
+        status, _, body = http_get(self.server, "/json?q=after-sandbox")
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(body)["hits"][0]["name"], "Mock.example")
+
+
+# ---------------------------------------------------------------------------
+# Two-worker scenario
+# ---------------------------------------------------------------------------
+
+class TwoWorkerTests(unittest.TestCase):
+    server: Server
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server = Server(workers=2)
+        cls.server.start()
+        cls.server.wait_listening()
+        cls.server.wait_workers_ready(2)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.stop()
+
+    def test_two_parallel_succeed_third_503s(self):
+        with WorkerHold(self.server) as a, WorkerHold(self.server) as b:
+            # Both workers are now held. A third request must 503 instantly.
+            status, headers, _ = http_get(self.server, "/json?q=hello")
+            self.assertEqual(status, 503)
+            self.assertEqual(headers.get("Retry-After"), "5")
+        self.assertEqual(a.status, 200)
+        self.assertEqual(b.status, 200)
+
+
+# ---------------------------------------------------------------------------
+# Greeting failure: worker never enters the pool
+# ---------------------------------------------------------------------------
+
+class NoGreetingTests(unittest.TestCase):
+    server: Server
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server = Server(workers=1, env_overrides={"MOCK_NO_GREETING": "1"})
+        cls.server.start()
+        cls.server.wait_listening()
+        # Block until server.py has logged the bring-up failure. Without
+        # this, our query might race against the bring-up thread.
+        cls.server.wait_log("did not send expected greeting")
+        cls.server.wait_log("did not come up cleanly")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.stop()
+
+    def test_query_503s_when_pool_empty(self):
+        status, headers, body = http_get(self.server, "/json?q=hello")
+        self.assertEqual(status, 503)
+        self.assertEqual(headers.get("Retry-After"), "5")
+        self.assertIn("under load", json.loads(body).get("error", ""))
+
+
+class WorkerLostTests(unittest.TestCase):
+    """If a worker dies AND the restart attempt also fails, the worker
+    should be dropped from the pool entirely (not silently re-pooled in
+    a broken state)."""
+
+    server: Server
+    fail_marker: Path
+
+    @classmethod
+    def setUpClass(cls):
+        # Path is passed to the mock; the file is absent at startup so
+        # the initial spawn sends a valid greeting. The test creates the
+        # file later, arming the *next* spawn to fail.
+        fd, path = tempfile.mkstemp(prefix="loogle-test-fail-")
+        os.close(fd)
+        cls.fail_marker = Path(path)
+        cls.fail_marker.unlink()
+        cls.server = Server(workers=1, env_overrides={
+            "MOCK_FAIL_GREETING_IF": str(cls.fail_marker),
+        })
+        cls.server.start()
+        cls.server.wait_listening()
+        cls.server.wait_workers_ready(1)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.stop()
+        if cls.fail_marker.exists():
+            cls.fail_marker.unlink()
+
+    def test_failed_restart_drops_worker(self):
+        # Arm: the next mock subprocess will see this file and refuse
+        # to send a valid greeting.
+        self.fail_marker.touch()
+        status, _, body = http_get(self.server, "/json?q=crash")
+        self.assertEqual(status, 200)
+        self.assertIn("removing worker from pool", json.loads(body)["error"])
+        # Pool is now empty for the rest of the process's life.
+        status, _, _ = http_get(self.server, "/json?q=hello")
+        self.assertEqual(status, 503)
+        # And the server should have logged the loss.
+        self.server.wait_log("Worker is dead after attempted restart")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/frontend-tests/test_server.py
+++ b/frontend-tests/test_server.py
@@ -49,9 +49,10 @@ def _free_port():
 class Server:
     """Lifecycle wrapper around a `python3 server.py` subprocess."""
 
-    def __init__(self, workers, env_overrides=None):
+    def __init__(self, workers, env_overrides=None, startup_timeout=5.0):
         self.workers = workers
         self.env_overrides = env_overrides or {}
+        self.startup_timeout = startup_timeout
         self.port = _free_port()
         self.proc = None
         self.log_path = None
@@ -73,7 +74,7 @@ class Server:
              "--port", str(self.port),
              "--workers", str(self.workers),
              "--restart-delay", "0.05",
-             "--startup-timeout", "5",
+             "--startup-timeout", str(self.startup_timeout),
              "--loogle-bin", str(MOCK_PATH)],
             cwd=str(ROOT),
             env=env,
@@ -353,6 +354,36 @@ class NoGreetingTests(unittest.TestCase):
         self.assertEqual(status, 503)
         self.assertEqual(headers.get("Retry-After"), "5")
         self.assertIn("under load", json.loads(body).get("error", ""))
+
+
+class StartupTimeoutTests(unittest.TestCase):
+    """A backend that hangs without printing a greeting must hit the
+    startup-timeout, get killed, and stay out of the pool — never
+    leaving a request thread blocked on readline()."""
+
+    server: Server
+
+    @classmethod
+    def setUpClass(cls):
+        cls.server = Server(
+            workers=1,
+            env_overrides={"MOCK_HANG_BEFORE_GREETING": "1"},
+            startup_timeout=0.3,
+        )
+        cls.server.start()
+        cls.server.wait_listening()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.stop()
+
+    def test_hanging_startup_times_out(self):
+        # Wait for the bring-up thread to log the timeout.
+        self.server.wait_log("did not send greeting within 0.3s")
+        self.server.wait_log("did not come up cleanly")
+        # Pool stays empty; queries load-shed.
+        status, _, _ = http_get(self.server, "/json?q=hello")
+        self.assertEqual(status, 503)
 
 
 class WorkerLostTests(unittest.TestCase):

--- a/frontend-tests/test_server.py
+++ b/frontend-tests/test_server.py
@@ -73,6 +73,7 @@ class Server:
              "--port", str(self.port),
              "--workers", str(self.workers),
              "--restart-delay", "0.05",
+             "--startup-timeout", "5",
              "--loogle-bin", str(MOCK_PATH)],
             cwd=str(ROOT),
             env=env,

--- a/server.py
+++ b/server.py
@@ -11,7 +11,6 @@ import time
 import re
 import os
 import queue
-import select
 import threading
 
 
@@ -214,27 +213,20 @@ class Loogle():
         return True
 
     def _read_greeting(self, timeout):
-        """Read one line from the backend's stdout, bounded by `timeout`
-        seconds. Returns the line (including newline) on success, b'' on
-        EOF, or None on timeout. Uses os.read so we don't fill the
-        buffered reader past the newline — subsequent queries use the
-        normal .readline() path."""
-        fd = self.loogle.stdout.fileno()
-        deadline = time.monotonic() + timeout
-        line = bytearray()
-        while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                return None
-            r, _, _ = select.select([fd], [], [], remaining)
-            if not r:
-                return None
-            chunk = os.read(fd, 1)
-            if not chunk:
-                return bytes(line)
-            line.extend(chunk)
-            if chunk == b"\n":
-                return bytes(line)
+        """Read the greeting line from the backend's stdout, bounded by
+        `timeout` seconds. Returns the line on success, b'' on EOF, or
+        None on timeout. A daemon thread does the blocking readline; on
+        timeout the caller kill()s the subprocess, which makes readline
+        return EOF and the thread exit cleanly."""
+        result = []
+        def reader():
+            result.append(self.loogle.stdout.readline())
+        t = threading.Thread(target=reader, daemon=True)
+        t.start()
+        t.join(timeout)
+        if t.is_alive():
+            return None
+        return result[0]
 
     def is_alive(self):
         return self.loogle.poll() is None

--- a/server.py
+++ b/server.py
@@ -174,16 +174,6 @@ class Loogle():
         self.start()
 
     def start(self):
-        # Reap any prior subprocess before spawning the replacement. The
-        # crash/sandbox paths in do_query already reaped via poll(), but
-        # the unresponsive path only kill()s — without an explicit wait()
-        # that zombie would linger until our own process exits.
-        prev = getattr(self, "loogle", None)
-        if prev is not None:
-            if prev.poll() is None:
-                prev.kill()
-            prev.wait()
-
         cmd = [loogleBin, "--json", "--interactive", *loogle_extra_args]
         if projectDir:
             cmd = ["lake", "-d", projectDir, "env", *cmd]
@@ -251,7 +241,10 @@ class Loogle():
             else:
                 reason, msg = "unresponsive", \
                     f"Backend did not respond ({e})."
-                self.loogle.kill() # ensure it's gone before we re-start
+                # kill+wait so start() doesn't leave a zombie behind.
+                # The crash/sandbox branches already reaped via poll().
+                self.loogle.kill()
+                self.loogle.wait()
             sys.stderr.write(f"{msg}\n")
             m_restarts.labels(reason).inc()
             if self.start():

--- a/server.py
+++ b/server.py
@@ -11,6 +11,7 @@ import time
 import re
 import os
 import queue
+import select
 import threading
 
 
@@ -33,6 +34,11 @@ def parse_args():
                         help="Seconds to wait for a misbehaving worker to "
                              "die before polling its exit code (default: "
                              "5.0). Lower values make the test suite quick.")
+    parser.add_argument("--startup-timeout", type=float, default=600.0,
+                        help="Seconds to wait for a worker subprocess to "
+                             "print its greeting before giving up on the "
+                             "startup attempt (default: 600). Caps the "
+                             "blast radius of a wedged backend on restart.")
     parser.add_argument("--workers", type=int, default=1,
                         help="Number of loogle worker subprocesses (default: "
                              "1). Each worker holds its own mathlib in RAM. "
@@ -48,10 +54,17 @@ def parse_args():
 
 
 args, loogle_extra_args = parse_args()
+if args.workers < 1:
+    sys.exit(f"--workers must be at least 1 (got {args.workers})")
+if args.restart_delay < 0:
+    sys.exit(f"--restart-delay must be non-negative (got {args.restart_delay})")
+if args.startup_timeout <= 0:
+    sys.exit(f"--startup-timeout must be positive (got {args.startup_timeout})")
 hostName = args.host
 serverPort = args.port
 loogleBin = args.loogle_bin
 restartDelay = args.restart_delay
+startupTimeout = args.startup_timeout
 projectDir = args.project_dir
 # Strip a leading "--" separator if the user used one to delimit forwarded args.
 if loogle_extra_args and loogle_extra_args[0] == "--":
@@ -162,6 +175,16 @@ class Loogle():
         self.start()
 
     def start(self):
+        # Reap any prior subprocess before spawning the replacement. The
+        # crash/sandbox paths in do_query already reaped via poll(), but
+        # the unresponsive path only kill()s — without an explicit wait()
+        # that zombie would linger until our own process exits.
+        prev = getattr(self, "loogle", None)
+        if prev is not None:
+            if prev.poll() is None:
+                prev.kill()
+            prev.wait()
+
         cmd = [loogleBin, "--json", "--interactive", *loogle_extra_args]
         if projectDir:
             cmd = ["lake", "-d", projectDir, "env", *cmd]
@@ -170,19 +193,48 @@ class Loogle():
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
         )
-        # Block until the backend signals readiness. Workers only enter the
-        # pool after this returns, so the dispatcher never hands out a worker
-        # that is still loading mathlib.
-        greeting = self.loogle.stdout.readline()
+        # Block until the backend signals readiness, with a generous
+        # timeout so a wedged subprocess doesn't hang the request thread
+        # that's restarting it. Workers only enter the pool after this
+        # returns True, so the dispatcher never hands out a worker that
+        # is still loading mathlib.
+        greeting = self._read_greeting(startupTimeout)
         if greeting != b"Loogle is ready.\n":
-            sys.stderr.write(
-                f"Backend did not send expected greeting (got: {greeting!r}).\n")
+            if greeting is None:
+                sys.stderr.write(
+                    f"Backend did not send greeting within {startupTimeout}s.\n")
+            else:
+                sys.stderr.write(
+                    f"Backend did not send expected greeting (got: {greeting!r}).\n")
             self.loogle.kill()
-            # Reap synchronously so is_alive() in the caller sees the dead
-            # subprocess immediately (kill() alone is asynchronous).
+            # Reap synchronously so is_alive() in the caller sees the
+            # dead subprocess immediately (kill() alone is asynchronous).
             self.loogle.wait()
             return False
         return True
+
+    def _read_greeting(self, timeout):
+        """Read one line from the backend's stdout, bounded by `timeout`
+        seconds. Returns the line (including newline) on success, b'' on
+        EOF, or None on timeout. Uses os.read so we don't fill the
+        buffered reader past the newline — subsequent queries use the
+        normal .readline() path."""
+        fd = self.loogle.stdout.fileno()
+        deadline = time.monotonic() + timeout
+        line = bytearray()
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
+            r, _, _ = select.select([fd], [], [], remaining)
+            if not r:
+                return None
+            chunk = os.read(fd, 1)
+            if not chunk:
+                return bytes(line)
+            line.extend(chunk)
+            if chunk == b"\n":
+                return bytes(line)
 
     def is_alive(self):
         return self.loogle.poll() is None

--- a/server.py
+++ b/server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import argparse
 import urllib
 import subprocess
@@ -10,7 +10,8 @@ import sys
 import time
 import re
 import os
-import select
+import queue
+import threading
 
 
 def parse_args():
@@ -28,6 +29,15 @@ def parse_args():
     parser.add_argument("--loogle-bin", default=".lake/build/bin/loogle",
                         help="Path to the loogle binary (default: "
                              ".lake/build/bin/loogle)")
+    parser.add_argument("--restart-delay", type=float, default=5.0,
+                        help="Seconds to wait for a misbehaving worker to "
+                             "die before polling its exit code (default: "
+                             "5.0). Lower values make the test suite quick.")
+    parser.add_argument("--workers", type=int, default=1,
+                        help="Number of loogle worker subprocesses (default: "
+                             "1). Each worker holds its own mathlib in RAM. "
+                             "Requests that arrive when all workers are busy "
+                             "receive HTTP 503.")
     parser.add_argument("--project-dir", default=None,
                         help="Lake project directory to serve. When set, the "
                              "loogle subprocess is invoked via `lake -d <dir> "
@@ -41,6 +51,7 @@ args, loogle_extra_args = parse_args()
 hostName = args.host
 serverPort = args.port
 loogleBin = args.loogle_bin
+restartDelay = args.restart_delay
 projectDir = args.project_dir
 # Strip a leading "--" separator if the user used one to delimit forwarded args.
 if loogle_extra_args and loogle_extra_args[0] == "--":
@@ -119,6 +130,10 @@ if prometheus_client is not None:
         m_info.info({'loogle': rev1})
     m_queries = prometheus_client.Counter('queries', 'Total number of queries')
     m_errors = prometheus_client.Counter('errors', 'Total number of failing queries')
+    m_load_shed = prometheus_client.Counter('load_shed', 'Requests rejected because all workers were busy')
+    m_restarts = prometheus_client.Counter('restarts', 'Backend worker restarts', ['reason'])
+    for l in ("sandbox", "died", "unresponsive"): m_restarts.labels(l)
+    m_workers_lost = prometheus_client.Counter('workers_lost', 'Workers permanently removed from the pool after a failed restart')
     m_results = prometheus_client.Histogram('results', 'Results per query', buckets=(0,1,2,5,10,50,100,200,500,1000))
     m_heartbeats = prometheus_client.Histogram('heartbeats', 'Heartbeats per query', buckets=(0,2e0,2e1,2e2,2e3,2e4))
     m_client = prometheus_client.Counter('clients', 'Clients used', ["client"])
@@ -132,7 +147,7 @@ else:
         def observe(self, *a, **kw): pass
         def labels(self, *a, **kw): return self
         def info(self, *a, **kw): pass
-    m_info = m_queries = m_errors = m_results = m_heartbeats = m_client = _NoopMetric()
+    m_info = m_queries = m_errors = m_results = m_heartbeats = m_client = m_load_shed = m_restarts = m_workers_lost = _NoopMetric()
 
 examples = [
     "Real.sin",
@@ -147,7 +162,6 @@ class Loogle():
         self.start()
 
     def start(self):
-        self.starting = True
         cmd = [loogleBin, "--json", "--interactive", *loogle_extra_args]
         if projectDir:
             cmd = ["lake", "-d", projectDir, "env", *cmd]
@@ -156,20 +170,24 @@ class Loogle():
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
         )
+        # Block until the backend signals readiness. Workers only enter the
+        # pool after this returns, so the dispatcher never hands out a worker
+        # that is still loading mathlib.
+        greeting = self.loogle.stdout.readline()
+        if greeting != b"Loogle is ready.\n":
+            sys.stderr.write(
+                f"Backend did not send expected greeting (got: {greeting!r}).\n")
+            self.loogle.kill()
+            # Reap synchronously so is_alive() in the caller sees the dead
+            # subprocess immediately (kill() alone is asynchronous).
+            self.loogle.wait()
+            return False
+        return True
+
+    def is_alive(self):
+        return self.loogle.poll() is None
 
     def do_query(self, query):
-        if self.starting:
-            r, w, e = select.select([ self.loogle.stdout ], [], [], 0)
-            if self.loogle.stdout in r:
-                greeting = self.loogle.stdout.readline()
-                if greeting != b"Loogle is ready.\n":
-                    self.loogle.kill() # just to be sure
-                    self.start()
-                    return {"error": "The backend process did not send greeting, killing and restarting..."}
-                else:
-                    self.starting = False
-            else:
-                return {"error": "The backend process is starting up, please try again later..."}
         try:
             self.loogle.stdin.write(bytes(query, "utf8"));
             self.loogle.stdin.write(b"\n");
@@ -178,25 +196,28 @@ class Loogle():
             output = json.loads(output_json)
             return output
         except (IOError, json.JSONDecodeError) as e:
-            time.sleep(5) # to allow the process to die
+            time.sleep(restartDelay) # to allow the process to die
             code = self.loogle.poll()
             if code == -31:
-                sys.stderr.write(f"Backend died trying to escape the sandbox.\n")
-                self.start()
-                return {"error":
-                    f"Backend died trying to escape the sandbox. Restarting..."
-                }
-            if code is not None:
-                sys.stderr.write(f"Backend died with code {code}.\n")
-                self.start()
-                return {"error":
-                    f"The backend process died with code {code}. Restarting..."
-                }
+                reason, msg = "sandbox", \
+                    "Backend died trying to escape the sandbox."
+            elif code is not None:
+                reason, msg = "died", \
+                    f"The backend process died with code {code}."
             else:
-                sys.stderr.write(f"Backend did not respond ({e}).\n")
-                self.loogle.kill() # just to be sure
-                self.start()
-                return {"error": "The backend process did not respond, killing and restarting..."}
+                reason, msg = "unresponsive", \
+                    f"Backend did not respond ({e})."
+                self.loogle.kill() # ensure it's gone before we re-start
+            sys.stderr.write(f"{msg}\n")
+            m_restarts.labels(reason).inc()
+            if self.start():
+                return {"error": f"{msg} Restarting..."}
+            # Restart itself failed (greeting bad). The handler will see
+            # is_alive() == False and drop the worker instead of pooling
+            # it. Surface that distinction to the user.
+            return {"error":
+                f"{msg} Backend failed to come up cleanly on restart; "
+                "removing worker from pool."}
 
     def query(self, query):
         m_queries.inc()
@@ -213,7 +234,38 @@ class Loogle():
 
 
 
-loogle = Loogle()
+pool = queue.Queue(maxsize=args.workers)
+
+def _bring_up_worker(i):
+    try:
+        w = Loogle()
+    except Exception as e:
+        sys.stderr.write(f"Worker {i} failed to start: {e}\n")
+        return
+    if w.loogle.poll() is not None:
+        # Start() killed the subprocess (bad greeting). Leave the worker
+        # out of the pool entirely so requests load-shed cleanly instead
+        # of being served by a dead pipe.
+        sys.stderr.write(f"Worker {i} did not come up cleanly; not adding to pool.\n")
+        return
+    pool.put(w)
+    sys.stderr.write(f"Worker {i} ready.\n")
+
+for i in range(args.workers):
+    threading.Thread(
+        target=_bring_up_worker, args=(i,), daemon=True,
+        name=f"loogle-bringup-{i}").start()
+
+def _return_or_drop_worker(worker):
+    """Put a worker back in the pool, unless its restart left it dead —
+    in which case the pool size effectively shrinks for the lifetime of
+    the process. Counts the loss so it's visible in /metrics."""
+    if worker.is_alive():
+        pool.put(worker)
+    else:
+        m_workers_lost.inc()
+        sys.stderr.write(
+            "Worker is dead after attempted restart; removing from pool.\n")
 
 # link formatting
 def locallink(query):
@@ -256,6 +308,18 @@ class MyHandler(HandlerBase):
             self.wfile.write(b"Invalid request.\n")
         except BrokenPipeError:
             # browsers seem to like to close this early
+            pass
+
+    def return503(self, content_type, body):
+        self.send_response(503)
+        self.send_header("Content-type", content_type)
+        self.send_header("Retry-After", "5")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Headers", "User-Agent, X-Loogle-Client")
+        self.end_headers()
+        try:
+            self.wfile.write(body)
+        except BrokenPipeError:
             pass
 
     def returnRedirect(self, url):
@@ -321,7 +385,17 @@ class MyHandler(HandlerBase):
             else:
                 query = message['data'].split('\n', 1)[0]
 
-            result = loogle.query(query)
+            try:
+                worker = pool.get(block=False)
+            except queue.Empty:
+                m_load_shed.inc()
+                self.returnJSON({ "content":
+                    "🛑 Loogle is currently under load, please try again in a moment." })
+                return
+            try:
+                result = worker.query(query)
+            finally:
+                _return_or_drop_worker(worker)
 
             if "error" in result:
                 if "\n" in result['error']:
@@ -359,6 +433,7 @@ class MyHandler(HandlerBase):
         try:
             query = ""
             result = {}
+            overloaded = False
             url = urllib.parse.urlparse(self.path)
             want_json = False
 
@@ -415,20 +490,36 @@ class MyHandler(HandlerBase):
                 query = params["q"][0].strip().removeprefix("#find ").strip()
                 if query:
                     query = re.sub(r'\s', ' ', query, flags=re.UNICODE)
-                    result = loogle.query(query)
+                    try:
+                        worker = pool.get(block=False)
+                    except queue.Empty:
+                        m_load_shed.inc()
+                        overloaded = True
+                    else:
+                        try:
+                            result = worker.query(query)
+                        finally:
+                            _return_or_drop_worker(worker)
 
-                if "lucky" in params:
+                if "lucky" in params and not overloaded:
                     if "hits" in result and len(result["hits"]) >= 1:
                         self.returnRedirect(doclink(result["hits"][0]))
                         return
 
 
             if want_json:
+                if overloaded:
+                    self.return503("application/json", bytes(json.dumps(
+                        {"error": "Loogle is currently under load, please try again later."}),
+                        "utf8"))
+                    return
                 self.returnJSON(result)
                 return
 
-            self.send_response(200)
+            self.send_response(503 if overloaded else 200)
             self.send_header("Content-type", "text/html")
+            if overloaded:
+                self.send_header("Retry-After", "5")
             self.end_headers()
             self.wfile.write(bytes("""
                 <!doctype html>
@@ -511,6 +602,11 @@ class MyHandler(HandlerBase):
                 </form>
                 </section>
             """, "utf-8"))
+            if overloaded:
+                self.wfile.write(b"""
+                    <h2>Loogle is currently under load</h2>
+                    <p>All worker processes are busy. Please try again in a few seconds.</p>
+                """)
             if "error" in result:
                 self.wfile.write(bytes(f"""
                     <h2>Error</h2>
@@ -605,7 +701,7 @@ class MyHandler(HandlerBase):
             pass
 
 if __name__ == "__main__":
-    webServer = HTTPServer((hostName, serverPort), MyHandler)
+    webServer = ThreadingHTTPServer((hostName, serverPort), MyHandler)
     print("Server started http://%s:%s" % (hostName, serverPort), flush=True)
 
     try:


### PR DESCRIPTION
Replace the single global Loogle subprocess with a queue.Queue-based
pool of N workers, served via ThreadingHTTPServer. Requests arriving
when the pool is empty receive HTTP 503 with Retry-After (/json and /),
or a friendly 200 "under load" content for /zulipbot. The HTML page
keeps the form so users can retry. Default --workers stays at 1 for
local single-user use; production picks a higher N manually.

A worker that dies during a query is restarted synchronously by the
owning request thread and pooled again. If the restart itself fails
the greeting handshake the worker is dropped from the pool entirely,
with a distinct error message and a workers_lost counter — better
than silently serving every subsequent request through a broken pipe.

New prometheus counters: load_shed, restarts{reason=sandbox|died|
unresponsive}, workers_lost. New flag --restart-delay lets the test
suite collapse the 5s wait-to-die into 50ms.

frontend-tests/: race-free end-to-end suite driven against a
mock-loogle.py that speaks the line-JSON protocol. The mock's `block
<fifo>` query plus FIFO open() pairing gives the test deterministic
sync points — no sleeps gate any concurrent state. Covers normal
queries, error pass-through, JSON/HTML/zulipbot load-shed, crash and
sandbox-signal restarts, N=2 concurrency, bad-greeting bring-up
failure, and the failed-restart drop-from-pool path. Runs in ~0.6s.

CI: new frontend-tests job runs in parallel with the Lean build;
needs only setup-python, no toolchain.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
